### PR TITLE
Paragraphpreview

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,6 @@
     "drupal/ckeditor": "^1.0",
     "drupal/config_ignore": "^2.1",
     "drupal/config_update": "^2.0@alpha",
-    "drupal/console": "~1.0",
     "drupal/content_access": "^2.0.0",
     "drupal/core": "^9.4.5",
     "drupal/core-composer-scaffold": "^9.2",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 ],
   "require": {
     "ahebrank/eck_autolabel": "^2.0.0",
-    "ahebrank/paragraphs_previewer_popup": "dev-8.x-1.x",
+    "ahebrank/paragraphs_previewer_popup": "^2.0.0",
     "bower-asset/dropzone": "5.7.2",
     "bower-asset/imagesloaded": "^4.1",
     "bower-asset/masonry": "^4.2",


### PR DESCRIPTION
Updated paragraphs_previewer_popup to the 2.0.0 release for D10 compatibility.  Removed drupal/console for now because I don't think any of us use it and when trying to update to D10 it is throwing php version errors.  